### PR TITLE
Fixes for modern glib, OpenSSL 1.1.0.

### DIFF
--- a/2.8.8-glib.patch
+++ b/2.8.8-glib.patch
@@ -1,0 +1,87 @@
+--- origsrc/xchat-2.8.8/src/common/dbus/dbus-plugin.c	2009-08-16 02:40:15.000000000 -0700
++++ src/xchat-2.8.8/src/common/dbus/dbus-plugin.c	2012-04-09 14:02:12.000000000 -0700
+@@ -24,7 +24,7 @@
+ #include <config.h>
+ #include <dbus/dbus-glib.h>
+ #include <dbus/dbus-glib-lowlevel.h>
+-#include <glib/gi18n.h>
++#include <glib.h>
+ #include "../xchat-plugin.h"
+ 
+ #define PNAME _("remote access")
+diff -Naurp origsrc/xchat-2.8.8/src/common/modes.c src/xchat-2.8.8/src/common/modes.c
+--- origsrc/xchat-2.8.8/src/common/modes.c	2010-05-29 18:52:18.000000000 -0700
++++ src/xchat-2.8.8/src/common/modes.c	2012-04-09 14:02:12.000000000 -0700
+@@ -20,7 +20,7 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <glib.h>
+-#include <glib/gprintf.h>
++#include <glib.h>
+ 
+ #include "xchat.h"
+ #include "xchatc.h"
+diff -Naurp origsrc/xchat-2.8.8/src/common/servlist.c src/xchat-2.8.8/src/common/servlist.c
+--- origsrc/xchat-2.8.8/src/common/servlist.c	2010-05-16 00:24:26.000000000 -0700
++++ src/xchat-2.8.8/src/common/servlist.c	2012-04-09 14:02:12.000000000 -0700
+@@ -24,7 +24,7 @@
+ #include <unistd.h>
+ 
+ #include "xchat.h"
+-#include <glib/ghash.h>
++#include <glib.h>
+ 
+ #include "cfgfiles.h"
+ #include "fe.h"
+diff -Naurp origsrc/xchat-2.8.8/src/common/text.c src/xchat-2.8.8/src/common/text.c
+--- origsrc/xchat-2.8.8/src/common/text.c	2010-05-29 19:14:41.000000000 -0700
++++ src/xchat-2.8.8/src/common/text.c	2012-04-09 14:02:12.000000000 -0700
+@@ -28,7 +28,7 @@
+ #include <sys/mman.h>
+ 
+ #include "xchat.h"
+-#include <glib/ghash.h>
++#include <glib.h>
+ #include "cfgfiles.h"
+ #include "chanopt.h"
+ #include "plugin.h"
+diff -Naurp origsrc/xchat-2.8.8/src/common/util.c src/xchat-2.8.8/src/common/util.c
+--- origsrc/xchat-2.8.8/src/common/util.c	2009-08-16 02:40:16.000000000 -0700
++++ src/xchat-2.8.8/src/common/util.c	2012-04-09 14:02:12.000000000 -0700
+@@ -39,7 +39,7 @@
+ #include <errno.h>
+ #include "xchat.h"
+ #include "xchatc.h"
+-#include <glib/gmarkup.h>
++#include <glib.h>
+ #include <ctype.h>
+ #include "util.h"
+ #include "../../config.h"
+diff -Naurp origsrc/xchat-2.8.8/src/common/xchat.h src/xchat-2.8.8/src/common/xchat.h
+--- origsrc/xchat-2.8.8/src/common/xchat.h	2009-08-16 02:40:16.000000000 -0700
++++ src/xchat-2.8.8/src/common/xchat.h	2012-04-09 14:01:05.000000000 -0700
+@@ -1,10 +1,6 @@
+ #include "../../config.h"
+ 
+-#include <glib/gslist.h>
+-#include <glib/glist.h>
+-#include <glib/gutils.h>
+-#include <glib/giochannel.h>
+-#include <glib/gstrfuncs.h>
++#include <glib.h>
+ #include <time.h>			/* need time_t */
+ 
+ #ifndef XCHAT_H
+diff -Naurp origsrc/xchat-2.8.8/src/fe-gtk/sexy-spell-entry.c src/xchat-2.8.8/src/fe-gtk/sexy-spell-entry.c
+--- origsrc/xchat-2.8.8/src/fe-gtk/sexy-spell-entry.c	2009-08-16 02:40:18.000000000 -0700
++++ src/xchat-2.8.8/src/fe-gtk/sexy-spell-entry.c	2012-04-09 14:02:12.000000000 -0700
+@@ -26,7 +26,7 @@
+ #include <gtk/gtk.h>
+ #include "sexy-spell-entry.h"
+ #include <string.h>
+-#include <glib/gi18n.h>
++#include <glib.h>
+ #include <sys/types.h>
+ /*#include "gtkspell-iso-codes.h"
+ #include "sexy-marshal.h"*/
+

--- a/2.8.8-openssl.patch
+++ b/2.8.8-openssl.patch
@@ -1,0 +1,117 @@
+diff -Naur origsrc/xchat-2.8.8/src/common/server.c src/xchat-2.8.8/src/common/server.c
+--- origsrc/xchat-2.8.8/src/common/server.c	2019-12-12 12:48:04.063415964 -0500
++++ src/xchat-2.8.8/src/common/server.c	2019-12-12 12:47:52.055415629 -0500
+@@ -598,10 +598,22 @@
+ 	char buf[512];
+ 
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++/* OpenSSL 1.1.0 and up: */
++	X509 *current_cert = X509_STORE_CTX_get_current_cert (ctx);
++	if (!current_cert)
++		return TRUE;
++	X509_NAME_oneline (X509_get_subject_name (current_cert),
++	                   subject, sizeof (subject));
++	X509_NAME_oneline (X509_get_issuer_name (current_cert),
++	                   issuer, sizeof (issuer));
++#else
++/* Pre-OpenSSL 1.1.0: */
+ 	X509_NAME_oneline (X509_get_subject_name (ctx->current_cert), subject,
+ 							 sizeof (subject));
+ 	X509_NAME_oneline (X509_get_issuer_name (ctx->current_cert), issuer,
+ 							 sizeof (issuer));
++#endif
+ 
+ 	snprintf (buf, sizeof (buf), "* Subject: %s", subject);
+ 	EMIT_SIGNAL (XP_TE_SSLMESSAGE, g_sess, buf, NULL, NULL, NULL, 0);
+@@ -751,8 +763,16 @@
+ 		return (0);					  /* remove it (0) */
+ 	} else
+ 	{
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++/* OpenSSL < 1.10 */
+ 		if (serv->ssl->session && serv->ssl->session->time + SSLTMOUT < time (NULL))
+ 		{
++#else
++/* OpenSSL 1.1.0 up */
++		SSL_SESSION *session = SSL_get_session (serv->ssl);
++		if (session && SSL_SESSION_get_time (session) + SSLTMOUT < time (NULL))
++		{
++#endif
+ 			snprintf (buf, sizeof (buf), "SSL handshake timed out");
+ 			EMIT_SIGNAL (XP_TE_CONNFAIL, serv->server_session, buf, NULL,
+ 							 NULL, NULL, 0);
+diff -Naur origsrc/xchat-2.8.8/src/common/ssl.c src/xchat-2.8.8/src/common/ssl.c
+--- origsrc/xchat-2.8.8/src/common/ssl.c	2019-12-12 12:48:06.839416041 -0500
++++ src/xchat-2.8.8/src/common/ssl.c	2019-12-12 12:47:55.235415717 -0500
+@@ -70,7 +70,7 @@
+ 
+ 	SSLeay_add_ssl_algorithms ();
+ 	SSL_load_error_strings ();
+-	ctx = SSL_CTX_new (server ? SSLv3_server_method() : SSLv3_client_method ());
++	ctx = SSL_CTX_new (server ? SSLv23_server_method() : SSLv23_client_method ());
+ 
+ 	SSL_CTX_set_session_cache_mode (ctx, SSL_SESS_CACHE_BOTH);
+ 	SSL_CTX_set_timeout (ctx, 300);
+@@ -136,6 +136,10 @@
+ _SSL_get_cert_info (struct cert_info *cert_info, SSL * ssl)
+ {
+ 	X509 *peer_cert;
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++	X509_PUBKEY *key;
++	X509_ALGOR *algor = NULL;
++#endif
+ 	EVP_PKEY *peer_pkey;
+ 	/* EVP_PKEY *ca_pkey; */
+ 	/* EVP_PKEY *tmp_pkey; */
+@@ -155,8 +159,18 @@
+ 	broke_oneline (cert_info->subject, cert_info->subject_word);
+ 	broke_oneline (cert_info->issuer, cert_info->issuer_word);
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++/* Old OpenSSL */
+ 	alg = OBJ_obj2nid (peer_cert->cert_info->key->algor->algorithm);
+ 	sign_alg = OBJ_obj2nid (peer_cert->sig_alg->algorithm);
++#else
++/* New OpenSSL */
++	key = X509_get_X509_PUBKEY(peer_cert);
++	if (!X509_PUBKEY_get0_param(NULL, NULL, 0, &algor, key))
++		return 1;
++	alg = OBJ_obj2nid (algor->algorithm);
++	sign_alg = X509_get_signature_nid (peer_cert);
++#endif
+ 	ASN1_TIME_snprintf (notBefore, sizeof (notBefore),
+ 							  X509_get_notBefore (peer_cert));
+ 	ASN1_TIME_snprintf (notAfter, sizeof (notAfter),
+@@ -171,7 +185,6 @@
+ 	strncpy (cert_info->sign_algorithm,
+ 				(sign_alg == NID_undef) ? "Unknown" : OBJ_nid2ln (sign_alg),
+ 				sizeof (cert_info->sign_algorithm));
+-	/* EVP_PKEY_bits(ca_pkey)); */
+ 	cert_info->sign_algorithm_bits = 0;
+ 	strncpy (cert_info->notbefore, notBefore, sizeof (cert_info->notbefore));
+ 	strncpy (cert_info->notafter, notAfter, sizeof (cert_info->notafter));
+@@ -274,6 +287,7 @@
+ _SSL_socket (SSL_CTX *ctx, int sd)
+ {
+ 	SSL *ssl;
++	const SSL_METHOD *method;
+ 
+ 
+ 	if (!(ssl = SSL_new (ctx)))
+@@ -281,7 +295,14 @@
+ 		__SSL_critical_error ("SSL_new");
+ 
+ 	SSL_set_fd (ssl, sd);
+-	if (ctx->method == SSLv3_client_method())
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++/* Old OpenSSL */
++	method = ctx->method;
++#else
++/* New OpenSSL */
++	method = SSL_CTX_get_ssl_method (ctx);
++#endif
++	if (method == SSLv23_client_method())
+ 		SSL_set_connect_state (ssl);
+ 	else
+ 	        SSL_set_accept_state(ssl);

--- a/xchat.cygport
+++ b/xchat.cygport
@@ -29,6 +29,8 @@ PATCH_URI="
 	2.8.8-plugins-dll.patch
 	2.8.8-plugins-no-undefined.patch
 	2.8.8-vpath.patch
+	2.8.8-glib.patch
+	2.8.8-openssl.patch
 "
 
 DIFF_EXCLUDES="inline_pngs.h *.pm.h"


### PR DESCRIPTION
This xchat port is a bit out of date; I've successfully built it this year in Cygwin and on other platforms after updating it for newer versions of glib and OpenSSL.
The glib patch is from https://trac.macports.org/attachment/ticket/33959/patch-glib-2.32.diff , and the OpenSSL patch was made by me copycatting the changes I found in hexchat, but I don't have a commit to point to since I was comparing the code from a release tarball.
Fixes #1.